### PR TITLE
Feature/do not repeat on amend

### DIFF
--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This way you can customize which branches should be skipped when
-# prepending commit message. 
+# prepending commit message.
 if [ -z "$BRANCHES_TO_SKIP" ]; then
   BRANCHES_TO_SKIP=(master develop test hotfix)
 fi
@@ -16,6 +16,8 @@ FEATURE_NUMBER=$(echo $BRANCH_NAME | sed -n 's/\([0-9]*\)\-.*/\1/p')
 BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
 BRANCH_IN_COMMIT=$(grep -c "\[$BRANCH_NAME\]" $1)
 
-if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]] && ! [[ $2 = merge  ]]; then
-  sed -i.bak -e "1s/^/CLOUDAC-$FEATURE_NUMBER /" $1
+prefix=CLOUDAC-$FEATURE_NUMBER:
+
+if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]] && ! [[ $2 = merge  ]] && ! [[ `cat $1` == $prefix* ]]; then
+  sed -i.bak -e "1s/^/$prefix /" $1
 fi


### PR DESCRIPTION
When amending a commit the prefix is already part of the commit message. We now check if the commit message already starts with the prefix and if it does, we just leave it as it is
